### PR TITLE
Use Rails/SafeNavigation default

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -119,9 +119,6 @@ Rails/OutputSafety:
 Rails/RakeEnvironment:
   Enabled: false
 
-Rails/SafeNavigation:
-  ConvertTry: true
-
 Rails/SkipsModelValidations:
   Enabled: false
 


### PR DESCRIPTION
We want to propose this lint only for `try!` and not for `try`, as the default linting rule does.

This is because this piece of code
```ruby
source.try(:vat_number)
```
means "get the `vat_number` attribute of `source`, and fallback to `nil` when `source` is `nil` or `source.respond_to?(:vat_number)` is `false`.

The proposed change that comes from Rubocop when we have the `ConvertTry: true` is this one:
```ruby
source&.vat_number
```
This has a different meaning because the part "fallback to `nil` when [...] `source.respond_to?(:vat_number)` is `false`" is not valid here, and in that case, the code gives the error `NoMethodError`